### PR TITLE
Invert the Gyro values to match gyro orientation

### DIFF
--- a/src/ReefwingAHRS.cpp
+++ b/src/ReefwingAHRS.cpp
@@ -764,7 +764,7 @@ EulerAngles LSM9DS1::fusionEulerAngles(int16_t accRaw[3], int16_t gyroRaw[3], in
   // Calibrate gyroscope
   FusionVector3 uncalibratedGyroscope;
 
-  uncalibratedGyroscope.axis = { gyroRaw[0], gyroRaw[1], gyroRaw[2] };
+  uncalibratedGyroscope.axis = { -(gyroRaw[0]), -(gyroRaw[1]), -(gyroRaw[2]) };
 
   FusionVector3 calibratedGyroscope = FusionCalibrationInertial(uncalibratedGyroscope, FUSION_ROTATION_MATRIX_IDENTITY, gyroscopeSensitivity, FUSION_VECTOR3_ZERO);
 


### PR DESCRIPTION
On my Arduino Nano 33 ble, the gyro direction is inverted. This created errors in all the fusion algorithms where the gyro would compensate the value in the wrong way, then the value would slowly be pulled back to the right value by the accelerometer.
Flipped the sign of each gyro values, and now the fusion filters are working again.