### PR TITLE
Corrected normalization of acceleration and magnetometer in Madgwick and Mahoney filters.

### DIFF
--- a/src/ReefwingAHRS.cpp
+++ b/src/ReefwingAHRS.cpp
@@ -546,19 +546,21 @@ void ReefwingAHRS::madgwickUpdate(SensorData d, float deltaT) {
 
   // Normalise accelerometer measurement
   norm = sqrt(d.ax * d.ax + d.ay * d.ay + d.az * d.az);
-  if (norm == 0.0f) return; // handle NaN
-  norm = 1.0f/norm;
-  d.ax *= norm;
-  d.ay *= norm;
-  d.az *= norm;
+  if (norm != 0.0f) {
+    norm = 1.0f/norm;
+    d.ax *= norm;
+    d.ay *= norm;
+    d.az *= norm;
+  }
 
   // Normalise magnetometer measurement
   norm = sqrt(d.mx * d.mx + d.my * d.my + d.mz * d.mz);
-  if (norm == 0.0f) return; // handle NaN
-  norm = 1.0f/norm;
-  d.mx *= norm;
-  d.my *= norm;
-  d.mz *= norm;
+  if (norm != 0.0f) {
+    norm = 1.0f/norm;
+    d.mx *= norm;
+    d.my *= norm;
+    d.mz *= norm;
+  }
 
   // Reference direction of Earth's magnetic field
   _2q0mx = 2.0f * _q.q0 * d.mx;
@@ -630,19 +632,21 @@ void ReefwingAHRS::mahoneyUpdate(SensorData d, float deltaT) {
 
   // Normalise accelerometer measurement
   norm = sqrtf(d.ax * d.ax + d.ay * d.ay + d.az * d.az);
-  if (norm == 0.0f) return; // handle NaN
-  norm = 1.0f / norm;        // use reciprocal for division
-  d.ax *= norm;
-  d.ay *= norm;
-  d.az *= norm;
+  if (norm != 0.0f) {
+    norm = 1.0f / norm;        // use reciprocal for division
+    d.ax *= norm;
+    d.ay *= norm;
+    d.az *= norm;
+  }
 
   // Normalise magnetometer measurement
   norm = sqrtf(d.mx * d.mx + d.my * d.my + d.mz * d.mz);
-  if (norm == 0.0f) return; // handle NaN
-  norm = 1.0f / norm;        // use reciprocal for division
-  d.mx *= norm;
-  d.my *= norm;
-  d.mz *= norm;
+  if (norm != 0.0f) {
+    norm = 1.0f / norm;        // use reciprocal for division
+    d.mx *= norm;
+    d.my *= norm;
+    d.mz *= norm;
+  }
 
   // Reference direction of Earth's magnetic field
   hx = 2.0f * d.mx * (0.5f - q2q2 - q3q3) + 2.0f * d.my * (q1q2 - q0q3) + 2.0f * d.mz * (q1q3 + q0q2);


### PR DESCRIPTION
This is another error that seems to have permeated all the Arduino versions of the Madgwick filter.

The error is in the normalization:

```
 norm = sqrt(d.mx * d.mx + d.my * d.my + d.mz * d.mz);
 if (norm == 0.0f) return; // handle NaN
``` 

The thing is, there is no NaN to handle. If norm is zero then the vector is zero and is already normalized. So the corrected code is:
```
if (norm != 0.0f) {
    norm = 1.0f/norm;
    d.mx *= norm;
    d.my *= norm;
    d.mz *= norm;
}
```

This allows the orientaion quaternion to be updated when the readings from the accelerometer or magnetometer are zero.

As well as being correct, this has the side benefit that the Madgwick and Mahoney filters can now be used without a magnetometer.

It also means that the orientaion quaternion is updated when the accelerometer readings are zero. In practice this probably never happens, but it is conceivable that the accelerometer values go to zero in trick manoeuvre where the motors are cut and the quadcopter goes into freefall.

NOTE: I have not built and run Reefwing-AHRS with this change. I am, however, using this change in my own implementation of a Madgwick filter and it works fine.

As an aside, I'd be interested to see if using a Madgwick filter with the xiao Sense board would improve the results enough to make this board a candidate for a flight controller. Like you, I think this is a very interesting little board.

What makes it even more interesting as a flight controller is that THRH20 has implemented the  nrf52840 radio communication with NRF24L01 radio protocol on the NRF52849 see https://tmrh20.blogspot.com/2022/11/xiao-ble-sense-nrf52840-radio.html This would allow use of an NRF24 transmitter (which came with many of the cheap toy quadcopters) to control a xiao Sense. So you would only need to add motor drivers and a voltage regulator to have a full flight controller.
